### PR TITLE
Remove Instant Health from Jaffa Cakes. Exploitable. 

### DIFF
--- a/src/main/java/app/tombplays/jaffactory/item/ModFoods.java
+++ b/src/main/java/app/tombplays/jaffactory/item/ModFoods.java
@@ -17,7 +17,6 @@ public class ModFoods {
             .saturationMod(0.8f).alwaysEat()
                 .effect(() -> new MobEffectInstance(MobEffects.REGENERATION, 200, 2), 1f)
                 .effect(() -> new MobEffectInstance(MobEffects.HEALTH_BOOST, 1200, 2), 1f)
-                .effect(() -> new MobEffectInstance(MobEffects.HEAL, 300, 4), 1f)
             .build();
 
     public static final FoodProperties JAFFA_CHOCOLATE = new FoodProperties.Builder().nutrition(4).fast()


### PR DESCRIPTION
Giving the effect instant health to a consumable is unbalanced, the player can essentially spam eating to stay alive indefinitely. In addition, it also makes potions of instant health obsolete. 

I made this PR to suggest removing instant health from **Jaffa Cakes** as regen and health boost are strong enough as is.

Cheers!